### PR TITLE
Manage map claims as a RawClaim

### DIFF
--- a/src/main/java/com/github/novotnyr/idea/jwt/ClaimUtils.java
+++ b/src/main/java/com/github/novotnyr/idea/jwt/ClaimUtils.java
@@ -13,6 +13,7 @@ import com.github.novotnyr.idea.jwt.datatype.DataTypeRegistry.DataType;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class ClaimUtils {
 
@@ -31,6 +32,10 @@ public class ClaimUtils {
         }
         List<Object> objects = claimValue.asList(Object.class);
         if (objects != null) {
+            return new RawClaim(claimName, claimValue);
+        }
+        Map<String, Object> map = claimValue.asMap();
+        if (map != null) {
             return new RawClaim(claimName, claimValue);
         }
 


### PR DESCRIPTION
Hi! Thank you for this plugin, it's very handy!

I've created this pull request just to cover one use case that it's not working for me at this moment. Consider the following JWT:

eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwianNvbiI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6WyJpdGVtMSIsIml0ZW0yIl19LCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.I0Ig0JI7Qeo6ZJMlNRuIn1yLK2MahheDcC1xcU_Ik08

that contains the following payload:
`{
  "sub": "1234567890",
  "json": {
    "key1": "value1",
    "key2": [
      "item1",
      "item2"
    ]
  },
  "name": "John Doe",
  "iat": 1516239022
}`


The problem is that the 'json' key is being displayed with an empty value in the table.

I've seen that it's using 'claimValue.asString()' as the value but it contains the standard Object to string value. Changing it to a Map it's working fine, but I'm not sure if it has any impact to other functionalities.

Thanks!

Pablo.