### PR TITLE
Bump jackson-databind version up to 2.17.2 to remove security vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.8.4")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
     implementation("com.auth0:java-jwt:3.2.0")
     implementation("org.ocpsoft.prettytime:prettytime:4.0.2.Final")
     implementation("org.bouncycastle:bcpkix-jdk15on:1.61")


### PR DESCRIPTION
This bumps the jackson-databind version up 2.17.2 to remove security vulnerabilities found in the current version - https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.8.4